### PR TITLE
修改VisionFive2的配置

### DIFF
--- a/boards.md
+++ b/boards.md
@@ -31,7 +31,7 @@ Tranlated in Chinese:
 | 2450  | SiFive HiFive Unmatched          | U74                     | - |
 | 1100   | LicheePi 3A           | 16GB RAM + 32GB eMMC                     | - |
 | 130   | Lichee RV Dock           | D1/C906                     | - |
-| 450   | VisionFive 2           | JH7100                     | - |
+| 450   | VisionFive 2           | JH7110                     | - |
 | 3599   | SpacemiT MUSEBook           | SpacemiT K1, 8GB memory, 128GB ssd | - |
 | 3999   | SpacemiT MUSEBook           | SpacemiT K1, 16GB memory, 256GB ssd | - |
 | 4599   | SpacemiT MUSEBook           | SpacemiT K1, 16GB memory, 512GB ssd | - |


### PR DESCRIPTION
StarFive VisionFive2采用的是jh7110 
信源:[官方网站](https://www.starfivetech.com/site/boards)